### PR TITLE
Fix disappearing autocomplete on click of search input

### DIFF
--- a/app/assets/javascripts/workarea/storefront/search_autocomplete/modules/search_autocomplete.js
+++ b/app/assets/javascripts/workarea/storefront/search_autocomplete/modules/search_autocomplete.js
@@ -25,7 +25,7 @@ WORKAREA.registerModule('searchAutocomplete', (function () {
         },
 
         handleUserClick = function (event) {
-            if (_.isEmpty($(event.target).closest($('#search_autocomplete')))) {
+            if (!$(event.target).is($(WORKAREA.config.searchAutocomplete.selector))) {
                 hide();
             }
         },


### PR DESCRIPTION
SEARCHAUTO-3

I don't know if this is a perfect solution, but it works better than what was there. The previous method was never returning true, and only didn't interfere on first click because of the delay of xhr request. 