### PR TITLE
Re-initialize modules on template response

### DIFF
--- a/app/assets/javascripts/workarea/storefront/search_autocomplete/modules/search_autocomplete.js
+++ b/app/assets/javascripts/workarea/storefront/search_autocomplete/modules/search_autocomplete.js
@@ -15,11 +15,15 @@ WORKAREA.registerModule('searchAutocomplete', (function () {
         },
 
         render = function (response) {
+            var $response = $(response);
+
+            WORKAREA.initModules($response);
+
             $('#search_autocomplete')
             .removeClass('visually-hidden')
             .addClass('search-autocomplete--visible')
             .empty()
-            .append(response)
+            .append($response)
                 .closest('.page-header__search-value')
                 .addClass('page-header__search-value--autocomplete');
         },


### PR DESCRIPTION
When the autocomplete view is rendered we need to re-initialize the
JavaScript modules to ensure that their functionality is provided to the
template.

SEARCHAUTO-4