### PR TITLE
Display Autocomplete on Mobile

### DIFF
--- a/app/assets/stylesheets/workarea/storefront/search_autocomplete/components/_search_autocomplete.scss
+++ b/app/assets/stylesheets/workarea/storefront/search_autocomplete/components/_search_autocomplete.scss
@@ -15,13 +15,12 @@ $search-autocomplete-z-indexes: ();
 }
 
 .search-autocomplete {
-    display: none;
+    display: block;
     background: $search-autocomplete-bg-color;
     border: $search-autocomplete-border;
     padding: $spacing-unit;
 
     @include respond-to($medium-breakpoint) {
-        display: block;
         width: 90vw;
     }
 
@@ -35,8 +34,25 @@ $search-autocomplete-z-indexes: ();
     top: 100%;
     right: 0;
     z-index: index($search-autocomplete-z-indexes, search-autocomplete);
+
+    @include respond-to($medium-breakpoint) {
+        left: auto;
+    }
 }
 
+    .search-autocomplete__heading {}
+
+    .search-autocomplete__heading--centered-at-small {
+        @include respond-to($small-breakpoint) {
+            text-align: center;
+            display: block;
+        }
+
+        @include respond-to($medium-breakpoint) {
+            text-align: left;
+            display: inline;
+        }
+    }
 
     .search-autocomplete__products {
         text-align: left;
@@ -44,9 +60,18 @@ $search-autocomplete-z-indexes: ();
 
 
     .search-autocomplete__searches {
-        @extend %list-reset;
-        text-align: right;
+        @include respond-to($small-breakpoint) {
+            text-align: center;
+        }
+
+        @include respond-to($medium-breakpoint) {
+            text-align: right;
+        }
     }
+
+        .search-autocomplete__searches-list {
+            @extend %list-reset;
+        }
 
         .search-autocomplete__searches-item {}
 

--- a/app/views/workarea/storefront/searches/autocomplete.html.haml
+++ b/app/views/workarea/storefront/searches/autocomplete.html.haml
@@ -1,23 +1,24 @@
 .grid.grid--rev
-  .grid__cell.grid__cell--25
+  .grid__cell.grid__cell--25-at-medium.grid__cell--100
     - if @autocomplete.searches.any?
-      %span.search-autocomplete__heading
-        - if @autocomplete.trending_searches?
-          = t('workarea.storefront.search_autocomplete.trending_searches')
-        - else
-          = t('workarea.storefront.search_autocomplete.popular_searches')
+      .search-autocomplete__searches
+        %span.search-autocomplete__heading
+          - if @autocomplete.trending_searches?
+            = t('workarea.storefront.search_autocomplete.trending_searches')
+          - else
+            = t('workarea.storefront.search_autocomplete.popular_searches')
 
-      %ul.search-autocomplete__searches
-        - @autocomplete.searches.each do |search|
-          %li.search-autocomplete__searches-item
-            = link_to search, search_path(q: search), class: 'search-autocomplete__searches-link'
+        %ul.search-autocomplete__searches-list
+          - @autocomplete.searches.each do |search|
+            %li.search-autocomplete__searches-item
+              = link_to search, search_path(q: search), class: 'search-autocomplete__searches-link'
 
     = append_partials('storefront.search_autocomplete_under_searches')
 
-  .grid__cell.grid__cell--75
+  .grid__cell.grid__cell--75-at-medium.grid__cell--100
     - if @autocomplete.products.any?
       .search-autocomplete__products
-        %span.search-autocomplete__heading
+        %span.search-autocomplete__heading.search-autocomplete__heading--centered-at-small
           - if @autocomplete.trending_products?
             = t('workarea.storefront.search_autocomplete.trending_products')
           - else
@@ -25,7 +26,7 @@
 
         .grid
           - @autocomplete.products.each do |product|
-            .grid__cell.grid__cell--25
+            .grid__cell.grid__cell--25-at-medium.grid__cell--100
               .product-summary
                 = render 'workarea/storefront/products/summary', product: product
 


### PR DESCRIPTION
The autocomplete was previously hidden on mobile devices since there were no styling rules applied for mobile out of the box. This is somewhat of a limitation as the plugin doesn't provide any "example" to follow if you're not using a theme that supports a mobile autocomplete.  On mobile devices, the autocomplete will now render in a slightly different layout, with trending/related searches appearing on top of the product results to better suit a portrait style view. Landscape view will not be supported as you can't really see anything in the autocomplete anyway.

Here's what it looks like on **iPhone**:
<img width="383" alt="Screen Shot 2020-06-30 at 5 40 43 PM" src="https://user-images.githubusercontent.com/113026/86179740-d5cf2680-baf8-11ea-808d-91c899157b56.png">

(Old screenshot, for reference)
<img width="496" alt="Screen Shot 2020-06-22 at 3 39 11 PM" src="https://user-images.githubusercontent.com/113026/85328553-ecdd9b00-b49e-11ea-908a-e5f67af7d133.png">

**iPad:**

<img width="773" alt="Screen Shot 2020-06-26 at 3 53 32 PM" src="https://user-images.githubusercontent.com/113026/85895720-3262d680-b7c5-11ea-8b9e-b27cd2c85df7.png">

...and **Desktop:**

<img width="1402" alt="Screen Shot 2020-06-26 at 3 54 07 PM" src="https://user-images.githubusercontent.com/113026/85895770-48709700-b7c5-11ea-951f-dcea78e14594.png">

Let me know if you'd like any changes to happen based on these screenshots! I haven't tried this out with any themes yet but that's my next step.