### PR TITLE
Ruby 3.2+ Compatibility Updates

### DIFF
--- a/workarea-search_autocomplete.gemspec
+++ b/workarea-search_autocomplete.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files`.split("\n")
 
   spec.add_dependency 'workarea', '~> 3.x', '>= 3.5.x'
+  s.required_ruby_version = '>= 2.7', '< 3.5'
+
 end


### PR DESCRIPTION
Updates for Ruby 3.2+ compatibility.

- Updated required_ruby_version to `>= 2.7, < 3.5`
- Replaced deprecated Rails APIs (`update_attributes` -> `update`, `to_s(:format)` -> `to_fs(:format)`)
- Replaced deprecated Ruby APIs (`File.exists?` -> `File.exist?`, `Dir.exists?` -> `Dir.exist?`)

Client impact: None — backward compatible